### PR TITLE
Fix the [DEPRECATED] default export warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import create, {
+import {
+  create,
   State,
   StateSelector,
   EqualityChecker,


### PR DESCRIPTION
Zustand gives a warning about using the default export, it's deprecated. You have to destructure the import of the `create` function, just like the other imports.

Addresses https://github.com/Diablow/zustand-store-addons/issues/9